### PR TITLE
Correct name for liquid water with I=75eV

### DIFF
--- a/parameters/defaults.rst
+++ b/parameters/defaults.rst
@@ -359,11 +359,11 @@ Materials
     d:Ma/Kapton/Density = 1.420 g/cm3
     s:Ma/Kapton/DefaultColor = "purple"
 
-    sv:Ma/Water_75/Components = 2 "Hydrogen" "Oxygen"
-    uv:Ma/Water_75/Fractions = 2 0.111894 0.888106
-    d:Ma/Water_75/Density = 1.0 g/cm3
-    d:Ma/Water_75/MeanExcitationEnergy = 75.0 eV
-    s:Ma/Water_75/DefaultColor = "blue"
+    sv:Ma/Water_75eV/Components = 2 "Hydrogen" "Oxygen"
+    uv:Ma/Water_75eV/Fractions = 2 0.111894 0.888106
+    d:Ma/Water_75eV/Density = 1.0 g/cm3
+    d:Ma/Water_75eV/MeanExcitationEnergy = 75.0 eV
+    s:Ma/Water_75eV/DefaultColor = "blue"
 
     sv:Ma/Titanium/Components = 1 "Titanium"
     uv:Ma/Titanium/Fractions = 1 1.0


### PR DESCRIPTION
According to the user forum post (https://groups.google.com/forum/#!msg/topas-mc-users/bUbgXVz2Dmw/ZIxcq2gjEgAJ) and own experience the name Water_75eV is correct while Water_75 is wrong

Setting `s:Ge/Phantom/Material = "Water_75"` gives an error:
```
Topas is exiting due to a serious error for material name: Water_75
This material has not been defined
```

while using `s:Ge/Phantom/Material = "Water_75eV"` works nicely:
```
Defined material named: Vacuum
Defined material named: Water_75eV
```

Full example here: https://gist.github.com/grzanka/bc798a537643dae0e84fe152ccaccb26