### PR TITLE
Update misc.rst

### DIFF
--- a/parameters/scoring/misc.rst
+++ b/parameters/scoring/misc.rst
@@ -49,7 +49,7 @@ Any scorer can be binned by particle energy, by adding the following parameters:
     d:Sc/MyScorer/EBinMin = 0. MeV # defaults to zero
     d:Sc/MyScorer/EBinMax = 100. MeV # must be specified if EBins is greater than 1
 
-The output will include three extra bins, one for underflow (energy < ``EBinMin``), one for overflow (energy > ``EBinMax``) and one for the case where there is no incident track (the primary particle was created already inside the scoring component, so it was never incident upon the scoring component).
+The output will include two extra bins, one (first) for underflow (energy < ``EBinMin``) and one (last) for overflow (energy > ``EBinMax``).
 
 Note that there are several options for what me mean here by "particle energy."
 


### PR DESCRIPTION
In TOPAS 3.2 it seems than two, not 3 extra bins are added.

Following configuration file block:
```
s:Sc/SPC_all/Quantity                  = "Fluence"
s:Sc/SPC_all/Component                 = "Phantom"
sv:Sc/SPC_all/Report = 1 "Mean"
i:Sc/SPC_all/EBins = 2000 # defaults to 1, that is, un-binned
d:Sc/SPC_all/EBinMin = 1e-15 MeV # defaults to zero
d:Sc/SPC_all/EBinMax = 72.523906 MeV # must be specified if EBins is greater than 1
s:Sc/SPC_all/EBinEnergy = "PreStep"
s:Sc/SPC_all/OutputType = "csv"
```

Gives CSV output like this:
```
# TOPAS Version: 3.2
# Parameter File: spc.txt
# Results for scorer SPC_all
# Scored in component: Phantom
# R in 1 bin  of 21 cm
# Phi in 1 bin  of 360 deg
# Z in 200 bins of 0.03 cm
# Fluence ( /mm2 ) : Mean   
# Binned by pre-step energy in 2000 bins of 0.036262 MeV from 1e-15 MeV to 72.5239 MeV
# First bin is underflow, last bin is overflow.
```

The same applies to the binary output.
I deliberately set EBinMin to 1e-15 to avoid scoring particles with zero kinetic energy.