### PR TITLE
Fix ReadTheDocs builds

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 Sphinx>=1.4.2
 docutils==0.17.1
--e git://github.com/davidchall/topas-pygments.git#egg=topas_pygments
+git+https://github.com/davidchall/topas-pygments.git#egg=topas_pygments


### PR DESCRIPTION
GitHub recently started blocking git protocol for download: [blogpost](https://github.blog/2021-09-01-improving-git-protocol-security-github/).