### PR TITLE
Migrate ReadTheDocs configuration

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,17 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
+sphinx:
+  configuration: conf.py
+
+python:
+  install:
+  - requirements: requirements.txt


### PR DESCRIPTION
Hi @jiperl!

I received a notification email, which pointed me to https://blog.readthedocs.com/migrate-configuration-v2/
> We plan to start failing builds not using configuration file version 2 on September 25, 2023.

I've taken their bare-bones example file and updated it for TOPAS. But I've not done any testing. 