### PR TITLE
manually set sphinx theme locally and when building on RTD

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -115,14 +115,7 @@ todo_include_todos = False
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-
-# on_rtd is whether we are on readthedocs.org
-on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
-if not on_rtd:  # only import and set the theme if we're building docs locally
-    import sphinx_rtd_theme
-    html_theme = 'sphinx_rtd_theme'
-    html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
-# otherwise, readthedocs.org uses their theme by default, so no need to specify it
+html_theme = 'sphinx_rtd_theme'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the


### PR DESCRIPTION
Not super familiar with editing Read The Docs, but the recent changes meant when I went to https://topas.readthedocs.io/en/latest/, I was seeing the documentation displayed in the "alabaster" theme. This created weird things like unreadable code formatting (see below). Tried a fix that seemed to work locally and when built by RTD online to keep the "sphix_rtd_theme" theme.

<img width="1009" alt="image" src="https://github.com/topasmc/topas-docs/assets/34250777/6aeb5ccb-c409-42bf-bee5-ab022cca7a48">
